### PR TITLE
Add JWT Validation

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -19,3 +19,17 @@ CLIENT_ID=<add-asgardeo-oidc-app-client-id-here>
 
 # The client secret for the Asgardeo OIDC app
 CLIENT_SECRET=<add-asgardeo-oidc-app-client-secret-here>
+
+# The URL of the issuer endpoint for the Asgardeo OIDC app
+ISSUER_URL=<add-asgardeo-oidc-app-issuer-endpoint-here>
+
+# The URL of the JWKS endpoint for the Asgardeo OIDC app
+JWKS_URL=<add-asgardeo-oidc-app-jwks-endpoint-here>
+
+# The client ID of the client application
+# Separate by commas if there's more than one.
+CLIENT_APP_ID=<add-client-application-client-id>
+
+# The method to use for the access token validation (optional)
+# instrospection (default) / jwtvalidate
+# ACCESS_TOKEN_VALIDATION_METHOD=<add-access-token-validation-method>

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "node": "18.x"
   },
   "dependencies": {
+    "aws-jwt-verify": "^4.0.0",
     "body-parser": "^1.20.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
This PR adds the following chages:
- Capability to validate the access token received from Asgardeo using Json Web Token validation.
- Config to define access token validation method. The default method is introspection.

Limitation
- JWT validation cannot recognize an access token that is revoked by the authorization server before the expiry of the token